### PR TITLE
Gfx perf bug

### DIFF
--- a/core/rendering/vk-utils/swapchain_image_context.h
+++ b/core/rendering/vk-utils/swapchain_image_context.h
@@ -26,9 +26,12 @@ private:
     VkRect2D scissor_{};
 
     std::vector <std::unique_ptr<RenderTarget>> renderTargets_;
-    std::unique_ptr<CmdBuffer> cmdBuffer_;
+    std::vector<std::unique_ptr<CmdBuffer>> cmdBuffs_;
 
 public:
+    uint32_t currFrame = 0;
+    static const int MAX_FRAMES_IN_FLIGHT = 2;
+
     SwapchainImageContext(const std::shared_ptr<RenderingContext>& renderingContext, uint32_t capacity,
                           const XrSwapchainCreateInfo &swapchainCreateInfo);
 

--- a/core/rendering/vk_context.cpp
+++ b/core/rendering/vk_context.cpp
@@ -89,10 +89,8 @@ void VulkanContext::InitializeResources() {
         InitPointCloudResources();
 }
 
-XrSwapchainImageBaseHeader* VulkanContext::AllocateSwapchainImageStructs(
-        uint32_t capacity, const XrSwapchainCreateInfo &swapchainCreateInfo) {
-    //
-
+XrSwapchainImageBaseHeader* VulkanContext::AllocateSwapchainImageStructs(uint32_t capacity,
+    const XrSwapchainCreateInfo &swapchainCreateInfo) {
     auto context = std::make_shared<SwapchainImageContext>(renderingContext_,
                                                                          capacity, swapchainCreateInfo);
     auto images = context->GetFirstImagePointer();

--- a/core/rendering/vk_context.cpp
+++ b/core/rendering/vk_context.cpp
@@ -143,7 +143,9 @@ void VulkanContext::RenderView(const XrCompositionLayerProjectionView &layerView
                 PrintWarning("PointLight missing spatial. Eid = " + std::to_string(pointLight->id));
             }
         }
-        uniformBuffer_->WriteToBuffer(&uboScene);
+        auto swapchainContext = imageToSwapchainContext_[swapchainImage];
+        uint32_t currFrame = swapchainContext->currFrame;
+        imgToUniformBuffs_[swapchainImage][currFrame]->WriteToBuffer(&uboScene);
     }
 
     // Update the transforms for each gltf model
@@ -157,7 +159,9 @@ void VulkanContext::RenderView(const XrCompositionLayerProjectionView &layerView
     swapchainContext->BeginRenderPass(imageIndex);
     swapchainContext->Draw(cubePipeline_, drawBuffer_, cubeMvps);
     for (auto& [name, model] : models_) {
-        swapchainContext->DrawGltf(gltfPipeline_, model, uboSceneDescriptorSet_);
+        uint32_t currFrame = swapchainContext->currFrame;
+        auto descriptorSet = imgToUboDescriptorSets_[swapchainImage][currFrame];
+        swapchainContext->DrawGltf(gltfPipeline_, model, descriptorSet);
         model->ClearPushConstants();
     }
     for (auto& [name, pointCloud] : pointClouds_) {
@@ -292,6 +296,8 @@ void VulkanContext::RetrieveQueues() {
 
 void VulkanContext::SwapchainImagesReady(XrSwapchainImageBaseHeader *images) {
     auto context = imageToSwapchainContext_[images];
+    imgToUniformBuffs_[images].resize(SwapchainImageContext::MAX_FRAMES_IN_FLIGHT);
+    imgToUboDescriptorSets_[images].resize(SwapchainImageContext::MAX_FRAMES_IN_FLIGHT);
     context->InitRenderTargets();
 }
 
@@ -336,11 +342,15 @@ void VulkanContext::InitGltfResources() {
     for (auto& name : uniqueNames)
         models_[name] = std::make_unique<GLTFModel>(renderingContext_, name + ".gltf");
 
-    uniformBuffer_ = std::make_unique<Buffer>(renderingContext_, sizeof(uboScene),
-                                              1, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                              MemoryType::HostVisible);
-    uniformBuffer_->Map();
-    uniformBuffer_->WriteToBuffer(&uboScene);
+    for (auto& [img, uniformBuffs] : imgToUniformBuffs_) {
+        for (auto& uniformBuff : uniformBuffs) {
+            uniformBuff = std::make_shared<Buffer>(renderingContext_, sizeof(uboScene),
+                                                   1, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                                                   MemoryType::HostVisible);
+            uniformBuff->Map();
+            uniformBuff->WriteToBuffer(&uboScene);
+        }
+    }
     SetupDescriptors();
 
     // Create the shader stages, add any push constants and/or descriptor set layouts
@@ -366,8 +376,13 @@ void VulkanContext::InitGltfResources() {
 void VulkanContext::SetupDescriptors() {
     // Setup the descriptor pool
     DescriptorPool::Builder builder(device_);
-    uint32_t maxSets = 1; // start with ubo
-    builder.AddPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1);
+    uint32_t maxSets = 0;
+    for (auto& [img, descriptorSets] : imgToUboDescriptorSets_) {
+        for (auto& descriptorSet : descriptorSets) {
+            maxSets++;
+        }
+    }
+    builder.AddPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, maxSets);
     for (auto& [name, model] : models_) {
         uint32_t numImages = model->GetNumImages();
         maxSets += numImages;
@@ -381,10 +396,14 @@ void VulkanContext::SetupDescriptors() {
             .AddBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
                         VK_SHADER_STAGE_ALL_GRAPHICS)
             .Build();
-    auto bufferInfo = uniformBuffer_->DescriptorInfo();
-    DescriptorWriter(*descriptorSetLayouts_["ubo"], *globalDescriptorPool_)
-        .WriteBuffer(0, &bufferInfo)
-        .Build(uboSceneDescriptorSet_);
+    for (auto& [img, descriptorSets] : imgToUboDescriptorSets_) {
+        for (size_t i = 0; i < descriptorSets.size(); i++) {
+            auto bufferInfo = imgToUniformBuffs_[img][i]->DescriptorInfo();
+            DescriptorWriter(*descriptorSetLayouts_["ubo"], *globalDescriptorPool_)
+                    .WriteBuffer(0, &bufferInfo)
+                    .Build(descriptorSets[i]);
+        }
+    }
 
     // For each model setup descriptor sets for materials
     for (auto& [name, model] : models_) {

--- a/core/rendering/vk_context.h
+++ b/core/rendering/vk_context.h
@@ -46,8 +46,8 @@ private:
     std::unique_ptr<ShaderStages> gltfShaderStages_;
     std::unique_ptr<Pipeline> gltfPipeline_;
     std::map<std::string, std::unique_ptr<GLTFModel>> models_;
-    std::unique_ptr<Buffer> uniformBuffer_;
-    VkDescriptorSet uboSceneDescriptorSet_;
+    std::map<const XrSwapchainImageBaseHeader*, std::vector<std::shared_ptr<Buffer>>> imgToUniformBuffs_;
+    std::map<const XrSwapchainImageBaseHeader*, std::vector<VkDescriptorSet>> imgToUboDescriptorSets_;
     struct PointLightData {
         glm::vec4 position; // ignore w
         glm::vec4 color;    // color + intensity

--- a/core/xr_context.cpp
+++ b/core/xr_context.cpp
@@ -207,9 +207,6 @@ void XrContext::CreateSwapchains() {
             vulkanContext_->SwapchainImagesReady(swapchainImages);
             swapchainImages_.insert(std::make_pair(swapchain.handle, swapchainImages));
         }
-
-//         Initialize resources once view and image information is up to date
-//        vulkanContext_->InitializeResources();
     }
 }
 


### PR DESCRIPTION
Finally fixed the graphics performance bug issue. Before when using uniform buffers, only one global uniform buffer could be used at a time, and at the end of the render pass (SwapchainImageContext::EndRenderPass()), the command buffer had to block on the CPU to avoid race conditions. In other words, to avoid having the CPU writing to a uniform buffer while that same buffer was being read/processed by the GPU. The issue was solved by allowing multiple uniform buffers each corresponding to only one command buffer. The issue was complicated by the fact that there are two instances of SwapchainImageContext (one per eye) since we are in VR.

An instance of SwapchainImageContext has MAX_FRAMES_IN_FLIGHT command buffers (note there may be more images in each swapchain, but this is the max that can be processed asynchronously by the GPU). Since there are two instances of SwapchainContext, this effectively totals to MAX_FRAMES_IN_FLIGHT * 2: command buffers, uniform buffers, and descriptor sets (though uniform buffers, and descriptor sets are kept in VulkanContext). In the end however, the result is that there is only one uniform buffer per frame in flight.

When testing the point cloud example the FPS was 48 without the fix and 60 with, for a ~10 FPS improvement! Note: that the point cloud is slow mostly because of the massive amount of vertices, but it makes for a good performance test.